### PR TITLE
Jjsfdc/setup remote changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,45 @@
-# Getting Started with [Fastify-CLI](https://www.npmjs.com/package/fastify-cli)
+# Lumina Solar API
 
-This project was bootstrapped with Fastify-CLI.
+API for use in software demos.
 
-## Available Scripts
+## Prerequisites
+* A [Heroku](https://www.heroku.com) account
 
-In the project directory, you can run:
+* [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli) installed
 
-### `npm run dev`
 
-To start the app in dev mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## Deploying to Heroku
+Clone this repo and open the resulting directory in your terminal
 
-### `npm start`
+Create **Heroku app**
+```
+heroku create <username>-lumina-solar
+```
 
-For production mode
+Provision **Heroku Postgres add-on** (incurs cost)
+```
+heroku addons:create heroku-postgresql:essential-0
+```
 
-### `npm run test`
+Follow CLI instructions to “check creation process”, continue when “State” is ```created```
 
-Run the test cases.
+Deploy the app
+```
+git push heroku main
+```
 
-## Learn More
+Import the database schema
+```
+heroku run npm run setup
+```
 
-To learn Fastify, check out the [Fastify documentation](https://fastify.dev/docs/latest/).
+Seed the database with example data
+```
+heroku run node data/seed.js
+```
+
+## Usage
+
+JSON OAS schema available at path ```/api-docs/json```
+
+To browse the schema visually, open path ```/``` in a web browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@fastify/autoload": "^5.0.0",
         "@fastify/sensible": "^5.0.0",
         "@fastify/swagger": "^8.14.0",
@@ -20,7 +21,6 @@
         "pg": "^8.11.3"
       },
       "devDependencies": {
-        "@faker-js/faker": "^8.4.1",
         "c8": "^9.0.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -146,7 +146,6 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
       "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@fastify/autoload": "^5.0.0",
     "@fastify/sensible": "^5.0.0",
     "@fastify/swagger": "^8.14.0",
@@ -31,7 +32,6 @@
     "pg": "^8.11.3"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.4.1",
     "c8": "^9.0.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",


### PR DESCRIPTION
* faker is now a regular, not dev dependency so that a user can set up the database in a Heroku Dyno instead of on their local machine
* README has rudimentary instructions on how to install this API in Heroku