### PR TITLE
added Apex-friendly schema for system summary

### DIFF
--- a/routes/api/index.js
+++ b/routes/api/index.js
@@ -2,6 +2,7 @@ import {
   systemSchema,
   metricSchema,
   errorSchema,
+  summarySchema,
 } from '../../schemas/index.js';
 
 export default async function (fastify, _opts) {
@@ -13,6 +14,11 @@ export default async function (fastify, _opts) {
   fastify.addSchema({
     $id: 'metric',
     ...metricSchema,
+  });
+
+  fastify.addSchema({
+    $id: 'summary',
+    ...summarySchema,
   });
 
   fastify.addSchema({
@@ -109,14 +115,7 @@ export default async function (fastify, _opts) {
           200: {
             description: 'Summary for the system',
             type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                date: { type: 'string', format: 'date' },
-                total_energy_produced: { type: 'number' },
-                total_energy_consumed: { type: 'number' },
-              },
-            },
+            items: { $ref: 'summary#' },
           },
           500: {
             description: 'Internal Server Error',
@@ -138,7 +137,12 @@ export default async function (fastify, _opts) {
          ORDER BY datetime::date DESC`,
         [systemId]
       );
-      reply.send(rows);
+      reply.send(rows.map(x => ({
+        systemid: systemId,
+        summarydate: x.date,
+        totalenergyproduced: x.total_energy_produced,
+        totalenergyconsumed: x.total_energy_consumed
+      })));
     }
   );
 }

--- a/schemas/index.js
+++ b/schemas/index.js
@@ -19,6 +19,17 @@ export const metricSchema = {
   required: ['system_id', 'energy_produced', 'energy_consumed'],
 };
 
+export const summarySchema = {
+  type: 'object',
+  properties: {
+    systemid: { type: 'string', format: 'uuid' },
+    summarydate: { type: 'string', format: 'date' },
+    totalenergyproduced: { type: 'number' },
+    totalenergyconsumed: { type: 'number' },
+  },
+  required: ['systemid', 'summarydate', 'totalenergyproduced', 'totalenergyconsumed'],
+};
+
 export const errorSchema = {
   type: 'object',
   properties: {


### PR DESCRIPTION
There was not a schema object for system summary, but I'd like to use one in a demo so I created the "summary" schema type.

Apex was also doing funny stuff with the underscore symbols (inserting system characters into the method names that get generated by External Services), so I opted to not use them for this schema.